### PR TITLE
fix: prevent null-type-inferring on specified types

### DIFF
--- a/playground/static/js/ast/constructors.js
+++ b/playground/static/js/ast/constructors.js
@@ -2,11 +2,9 @@ export function RTValue(content, type) {
     this.type = 'Value';
     this.content = content;
     if (content === undefined)
-    {
         this.type = 'EmptyValue';
-        this.valType = '?'; // Optional type
-    }
-    else this.valType = type ?? LitPattern.inferType(content);
+
+    this.valType = type ?? LitPattern.inferType(content);
 }
 
 export function RTExpression(content) {


### PR DESCRIPTION
### Explanation:

You create a `RTValue` with undefined value, but type `uint`:

1. `RTValue` detects the undefined value and sets the type to "EmptyValue"

2. If the value type is set to "EmptyValue" then it's going to assume the type is always "?".

3. Type gets discarded, that's what's causing the error.